### PR TITLE
Simplify Moodle Code Checker command by removing excluded standards

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Moodle Code Checker
         if: ${{ !cancelled() }}
-        run: moodle-plugin-ci phpcs --standard=moodle --exclude=moodle.Files.BoilerplateComment,moodle.PHP.IncludingFile,moodle.Commenting.InlineComment,Generic.NamingConventions.ConstructorName,moodle.Files.LineLength,moodle.ControlStructures.ControlSignature,moodle.Strings.ForbiddenStrings,moodle.Commenting.Package,NormalizedArrays.Arrays.CommaAfterLast,moodle.Commenting.MissingDocblock,moodle.Commenting.FileExpectedTags,moodle.Files.RequireLogin,moodle.Files.MoodleInternal,Generic.Arrays.DisallowLongArraySyntax,moodle.Commenting.VariableComment --max-warnings 50
+        run: moodle-plugin-ci phpcs --standard=moodle --max-warnings 50
 
       - name: PHPUnit tests
         if: ${{ !cancelled() }}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Moodle Plugin Quality Check](https://github.com/khairu-aqsara/terusrag/actions/workflows/main.yml/badge.svg)](https://github.com/khairu-aqsara/terusrag/actions/workflows/main.yml)
 # Terus Rag Block for Moodle
 
 ## Overview
@@ -95,9 +96,32 @@ This plugin supports two AI providers for handling RAG operations:
    - Configure OpenAI endpoint and model preferences
 5. Save changes and initialize the data process
 
+## Scheduled Tasks
+The plugin includes scheduled tasks to maintain and update the vector embeddings of course content:
+
+1. Content Indexing Task
+   - Runs daily by default
+   - Scans course content for changes
+   - Updates vector embeddings for modified content
+
+2. Running Tasks Manually
+   - Via CLI:
+     ```bash
+     # List all tasks
+     php admin/cli/scheduled_task.php --list
+
+     # Run content indexing task
+     php admin/cli/scheduled_task.php --execute=\\block_terusrag\\task\\datainitializer
+     ```
+   - Via Web Interface:
+     1. Go to Site Administration → Server → Scheduled tasks
+     2. Locate "TerusRAG content indexing" or "TerusRAG embeddings cleanup"
+     3. Click "Run now"
+
 ## Core Files
 - **provider_interface.php**: Interface defining LLM provider capabilities
 - **gemini.php**: Implementation of the Gemini API integration
+- **openai.php**: Implementation of the OpenAI API integration
 - **bm25.php**: BM25 ranking algorithm for text retrieval
 - **llm.php**: Helper class with vector operations for LLM processing
 

--- a/classes/openai.php
+++ b/classes/openai.php
@@ -56,7 +56,7 @@ class openai implements provider_interface {
 
     /**
      * Constructor for the OpenAI provider.
-     * 
+     *
      * Initializes the provider with API credentials, model settings,
      * and configures the HTTP client for API communication.
      */
@@ -345,8 +345,8 @@ class openai implements provider_interface {
                     ];
 
                     $isexists = $DB->get_record('block_terusrag', [
-                            'contenthash' => $contenthash, 
-                            'moduleid' => $coursellm['moduleid']
+                            'contenthash' => $contenthash,
+                            'moduleid' => $coursellm['moduleid'],
                         ]
                     );
 


### PR DESCRIPTION
This pull request includes a change to the `jobs:` section in the `.github/workflows/main.yml` file, specifically in the Moodle Code Checker step. The change simplifies the `phpcs` command by removing several exclusions.

Simplification of Moodle Code Checker command:

* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L71-R71): Removed multiple exclusion rules from the `phpcs` command, leaving only the `--standard=moodle` and `--max-warnings 50` options.