### PR TITLE
Division zero fix

### DIFF
--- a/classes/gemini.php
+++ b/classes/gemini.php
@@ -381,8 +381,22 @@ class gemini implements provider_interface {
         try {
             $batch = [];
             $llm = new llm();
-            $bm25 = new bm25([]);
+            $documents = [];
 
+            // First pass - collect documents for BM25 indexing.
+            foreach ($rs as $record) {
+                $documents[$record->id] = $record->content;
+                $contentarray[$record->id] = $record->content;
+            }
+
+            // Initialize BM25 with collected documents.
+            $bm25 = new bm25($documents);
+
+            // Reset recordset for second pass.
+            $rs->close();
+            $rs = $DB->get_recordset_sql($sql);
+
+            // Second pass - process chunks.
             foreach ($rs as $record) {
                 $batch[] = $record;
                 $contentarray[$record->id] = $record->content;

--- a/classes/ollama.php
+++ b/classes/ollama.php
@@ -353,8 +353,22 @@ class ollama implements provider_interface {
         try {
             $batch = [];
             $llm = new llm();
-            $bm25 = new bm25([]);
+            $documents = [];
 
+            // First pass - collect documents for BM25 indexing.
+            foreach ($rs as $record) {
+                $documents[$record->id] = $record->content;
+                $contentarray[$record->id] = $record->content;
+            }
+
+            // Initialize BM25 with collected documents.
+            $bm25 = new bm25($documents);
+
+            // Reset recordset for second pass.
+            $rs->close();
+            $rs = $DB->get_recordset_sql($sql);
+
+            // Second pass - process chunks.
             foreach ($rs as $record) {
                 $batch[] = $record;
                 $contentarray[$record->id] = $record->content;

--- a/classes/openai.php
+++ b/classes/openai.php
@@ -210,8 +210,22 @@ class openai implements provider_interface {
         try {
             $batch = [];
             $llm = new llm();
-            $bm25 = new bm25([]);
+            $documents = [];
 
+            // First pass - collect documents for BM25 indexing.
+            foreach ($rs as $record) {
+                $documents[$record->id] = $record->content;
+                $contentarray[$record->id] = $record->content;
+            }
+
+            // Initialize BM25 with collected documents.
+            $bm25 = new bm25($documents);
+
+            // Reset recordset for second pass.
+            $rs->close();
+            $rs = $DB->get_recordset_sql($sql);
+
+            // Second pass - process chunks.
             foreach ($rs as $record) {
                 $batch[] = $record;
                 $contentarray[$record->id] = $record->content;

--- a/lang/en/block_terusrag.php
+++ b/lang/en/block_terusrag.php
@@ -61,7 +61,11 @@ $string['promptsettings'] = 'Prompt Settings';
 $string['promptsettings_desc'] = 'Configure system prompts';
 $string['system_prompt'] = 'System Prompt';
 $string['system_prompt_desc'] = 'Base system prompt for RAG responses';
-$string['system_prompt_default'] = 'You are a Moodle assistant specialized in answering questions about course materials. Use only the provided context to construct your response.';
+$string['system_prompt_default'] = 'You are a Moodle assistant specializing in answering inquiries about materials. Rely solely on the given context to formulate your response Responses should adhere to the following format:
+
+[index] the context
+
+If the information is unknown, simply state "don\'t know."';
 $string['stopwords_not_found'] = 'Stop words file not found';
 $string['unknowncourse'] = 'Unknown course';
 $string['noresultsfound'] = 'No results found';

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2025032623;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2025032700;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2022111800;        // Requires this Moodle version (Moodle 4.1.3+).
 $plugin->component = 'block_terusrag'; // Full name of the plugin (used for diagnostics).
 $plugin->maturity = MATURITY_STABLE;
-$plugin->release = 'v1.0.2';
+$plugin->release = 'v1.0.3';


### PR DESCRIPTION
This pull request includes several changes to improve the handling of empty documents and enhance the BM25 class, as well as updates to the `get_top_ranked_chunks` method in multiple files. Additionally, there are modifications to the system prompt and plugin version.

Improvements to BM25 class:

* [`classes/bm25.php`](diffhunk://#diff-1a2f00617d4612eea840db0faf14ef7c4899096085afa4b3fee523b664b30ab7R57-R63): Added checks for empty documents array in the constructor and score method to handle cases where no documents are present. Also, added checks to prevent division by zero. [[1]](diffhunk://#diff-1a2f00617d4612eea840db0faf14ef7c4899096085afa4b3fee523b664b30ab7R57-R63) [[2]](diffhunk://#diff-1a2f00617d4612eea840db0faf14ef7c4899096085afa4b3fee523b664b30ab7R75-R76) [[3]](diffhunk://#diff-1a2f00617d4612eea840db0faf14ef7c4899096085afa4b3fee523b664b30ab7R89-R102) [[4]](diffhunk://#diff-1a2f00617d4612eea840db0faf14ef7c4899096085afa4b3fee523b664b30ab7L92-R120)

Enhancements to `get_top_ranked_chunks` method:

* `classes/gemini.php`, `classes/ollama.php`, `classes/openai.php`: Updated the method to collect documents in a first pass and initialize the BM25 class with these documents before processing chunks in a second pass. [[1]](diffhunk://#diff-55155df2f202a23c7d933953ba4f5a208311c997e9e970bbe851ab7bdeb9de2cL384-R399) [[2]](diffhunk://#diff-249b537f48d649cc42ea7dc3e4085e246b59f93bdb10636be003d4c6c5affaf9L356-R371) [[3]](diffhunk://#diff-ff16c6a36d35a49102a55da74556d5719de9ebe036c47a9fb7ed96e99f06f5d2L213-R228)

System prompt update:

* [`lang/en/block_terusrag.php`](diffhunk://#diff-891d86afe4c994785a8c355958afa51ca81b51761f3e8a5502bb69f7979c3f51L64-R68): Modified the default system prompt to provide a new format for responses and instructions for unknown information.

Plugin version update:

* [`version.php`](diffhunk://#diff-0dc418129946563e59bb69680a5ef0ded4329ed9e56e3d295c25e12ea726726bL28-R32): Updated the plugin version and release information to reflect the latest changes.