### PR TITLE
Open ai bug fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,14 @@
 ## Overview
 This Moodle block plugin implements Retrieval-Augmented Generation (RAG) functionality, allowing users to query course content using large language models. The plugin integrates with either Google's Gemini API, Ollama or OpenAI to provide intelligent responses based on your course data.
 
+### Searchable Content
+For now the plugin indexes and makes searchable the Course descriptions and summaries
+
+The content is automatically processed and indexed during the daily scheduled task, with immediate indexing occurring when content is created or modified.
+
 ## Features
 - Implements RAG (Retrieval-Augmented Generation) architecture
-- Integrates with Google's Gemini API and OpenAI
+- Integrates with Google's Gemini API, OpenAI, and Ollama
 - Supports vector embeddings for semantic search
 - Uses hybrid ranking with BM25 and cosine similarity
 - Automatically processes and indexes course content
@@ -72,7 +77,7 @@ graph TB
 
 ## AI Providers
 
-This plugin supports two AI providers for handling RAG operations:
+This plugin supports three AI providers for handling RAG operations:
 
 1. Google Gemini (Default)
    - Uses Gemini 2.0 Flash for chat completions
@@ -80,7 +85,7 @@ This plugin supports two AI providers for handling RAG operations:
    - Direct integration with Google AI Studio
    - Optimized for performance and cost-effectiveness
 
-2. OpenAI (Alternative)
+2. OpenAI
    - Supports GPT-4 and GPT-3.5 models
    - Multiple embedding model options:
      * text-embedding-3-large
@@ -88,6 +93,14 @@ This plugin supports two AI providers for handling RAG operations:
      * text-embedding-ada-002
    - Flexible API endpoint configuration
    - Enterprise-grade capabilities
+
+3. Ollama
+   - Supports multiple open-source models
+   - Available embedding models:
+     * nomic-embed-text
+     * all-minilm (33M and 22M variants)
+   - Local deployment option
+   - Cost-effective solution
 
 ## Installation
 1. Copy the terusrag folder into your Moodle blocks directory
@@ -98,20 +111,25 @@ This plugin supports two AI providers for handling RAG operations:
 ## Requirements
 - Moodle 4.1.3 or later
 - PHP 7.4 or later
-- Access to either:
-  * Gemini API (for default provider)
-  * OpenAI API (for alternative provider)
+- Access to one of:
+  * Gemini API (default provider)
+  * OpenAI API
+  * Ollama API (local or remote instance)
 
 ## Configuration
 1. Go to Site Administration → Plugins → Blocks → Terus RAG
-2. Choose your preferred AI provider (Gemini or OpenAI)
+2. Choose your preferred AI provider (Gemini, OpenAI, or Ollama)
 3. For Gemini:
    - Obtain API key from Google AI Studio
    - Configure Gemini endpoint and model settings
 4. For OpenAI:
    - Obtain API key from OpenAI platform
    - Configure OpenAI endpoint and model preferences
-5. Save changes and initialize the data process
+5. For Ollama:
+   - Set up Ollama instance (local or remote)
+   - Configure Ollama endpoint and selected models
+   - Specify embedding model preferences
+6. Save changes and initialize the data process
 
 ## Scheduled Tasks
 The plugin includes scheduled tasks to maintain and update the vector embeddings of course content:
@@ -120,8 +138,12 @@ The plugin includes scheduled tasks to maintain and update the vector embeddings
    - Runs daily by default
    - Scans course content for changes
    - Processes course content which includes:
-     * Course summary (primary source)
-     * Course full name (fallback if summary is empty)
+     * Course descriptions and summaries
+     * Course section descriptions
+     * Resource descriptions and content
+     * Activity descriptions and content (assignments, quizzes, forums, etc.)
+     * Book and page module content
+     * Labels and HTML blocks content
    - Updates vector embeddings for modified content
    - Re-indexes content when course information changes
 

--- a/classes/llm.php
+++ b/classes/llm.php
@@ -44,7 +44,7 @@ class llm {
         $normb = 0;
 
         foreach ($vectora as $key => $value) {
-            if(isset($vectorb[$key])) {
+            if (isset($vectorb[$key])) {
                 $dotproduct += $value * $vectorb[$key];
                 $norma += $value ** 2;
                 $normb += $vectorb[$key] ** 2;

--- a/classes/llm.php
+++ b/classes/llm.php
@@ -44,9 +44,11 @@ class llm {
         $normb = 0;
 
         foreach ($vectora as $key => $value) {
-            $dotproduct += $value * $vectorb[$key];
-            $norma += $value ** 2;
-            $normb += $vectorb[$key] ** 2;
+            if(isset($vectorb[$key])) {
+                $dotproduct += $value * $vectorb[$key];
+                $norma += $value ** 2;
+                $normb += $vectorb[$key] ** 2;
+            }
         }
 
         $norma = sqrt($norma);

--- a/classes/openai.php
+++ b/classes/openai.php
@@ -283,7 +283,7 @@ class openai implements provider_interface {
     protected function process_chunk_batch($batch, $queryembedding, $query, $llm, $bm25, &$chunkscores, &$bm25scores) {
         foreach ($batch as $chunk) {
             $chunkembedding = unserialize($chunk->embedding);
-            if ($chunkembedding) {
+            if ($chunkembedding && is_array($chunkembedding)) {
                 $chunkscores[$chunk->id] = $llm->cosine_similarity($queryembedding, $chunkembedding);
                 $bm25scores[$chunk->id] = $bm25->score($query, $chunk->content, $chunk->id);
             } else {

--- a/db/install.xml
+++ b/db/install.xml
@@ -18,7 +18,7 @@
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
-        <KEY NAME="contenthash" TYPE="unique" FIELDS="contenthash"/>
+        <KEY NAME="contenthash_moduleid" TYPE="unique" FIELDS="contenthash,moduleid"/>
       </KEYS>
     </TABLE>
   </TABLES>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -86,5 +86,21 @@ function xmldb_block_terusrag_upgrade($oldversion) {
         upgrade_block_savepoint(true, 2025031104, 'terusrag');
     }
 
+    if ($oldversion < 2025040512) {
+        // Get manager.
+        $table = new xmldb_table('block_terusrag');
+
+        // Remove existing unique key.
+        $key = new xmldb_key('contenthash', XMLDB_KEY_UNIQUE, ['contenthash']);
+        $dbman->drop_key($table, $key);
+
+        // Add new composite unique key.
+        $key = new xmldb_key('contenthash_moduleid', XMLDB_KEY_UNIQUE, ['contenthash', 'moduleid']);
+        $dbman->add_key($table, $key);
+
+        // Terusrag savepoint reached.
+        upgrade_block_savepoint(true, 2025040512, 'terusrag');
+    }
+
     return true;
 }

--- a/lang/en/block_terusrag.php
+++ b/lang/en/block_terusrag.php
@@ -60,7 +60,7 @@ $string['vectordb_password_desc'] = 'Password for authenticating with the vector
 $string['promptsettings'] = 'Prompt Settings';
 $string['promptsettings_desc'] = 'Configure system prompts';
 $string['system_prompt'] = 'System Prompt';
-$string['system_prompt_desc'] = 'Base system prompt for RAG responses';
+$string['system_prompt_desc'] = 'Base system prompt for RAG responses (do not remove [index] from the prompt)';
 $string['system_prompt_default'] = 'You are a Moodle assistant specializing in answering inquiries about materials. Rely solely on the given context to formulate your response Responses should adhere to the following format:
 
 [index] the context
@@ -73,10 +73,6 @@ $string['notokeninformation'] = 'No token information available';
 
 // Scheduled task strings.
 $string['datainitializer'] = 'Data Initializer';
-$string['datainitializer_desc'] = 'Initialize data for the Terus RAG block';
-
-// Config.
-$string['config_title'] = 'Block title';
 
 // Frontend.
 $string['queryplaceholder'] = 'Type your question here...';

--- a/tests/mock_provider.php
+++ b/tests/mock_provider.php
@@ -1,0 +1,163 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace block_terusrag;
+
+defined('MOODLE_INTERNAL') || die();
+
+global $CFG;
+require_once($CFG->dirroot . '/blocks/terusrag/classes/provider_interface.php');
+
+/**
+ * Mock provider implementation for testing.
+ *
+ * @package    block_terusrag
+ * @copyright  2025 Terus e-Learning
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class mock_provider implements provider_interface {
+    /** @var array Mock embeddings storage */
+    private array $mockembeddings;
+
+    /** @var array Mock responses storage */
+    private array $mockresponses;
+
+    /**
+     * Constructor initializes mock data.
+     */
+    public function __construct() {
+        $this->mockembeddings = [];
+        $this->mockresponses = [];
+    }
+
+    /**
+     * Set mock embedding for a specific input.
+     *
+     * @param string|array $input The input text
+     * @param array $embedding The embedding to return
+     */
+    public function set_mock_embedding($input, array $embedding) {
+        $key = is_array($input) ? json_encode($input) : $input;
+        $this->mockembeddings[$key] = $embedding;
+    }
+
+    /**
+     * Set mock response for a specific prompt.
+     *
+     * @param string $prompt The input prompt
+     * @param array $response The response to return
+     */
+    public function set_mock_response(string $prompt, array $response) {
+        $this->mockresponses[$prompt] = $response;
+    }
+
+    /**
+     * Get embedding vectors for the given text.
+     *
+     * @param string|array $query Text to generate embeddings for
+     * @return array Array of embedding values
+     */
+    public function get_embedding($query) {
+        $key = is_array($query) ? json_encode($query) : $query;
+        return $this->mockembeddings[$key] ?? array_fill(0, 384, 0.0);
+    }
+
+    /**
+     * Get a response from the mock provider.
+     *
+     * @param mixed $prompt The prompt to send
+     * @return array The mock response
+     */
+    public function get_response($prompt): array {
+        return $this->mockresponses[$prompt] ?? [
+            'content' => 'Mock response',
+            'promptTokenCount' => 10,
+            'responseTokenCount' => 20,
+            'totalTokenCount' => 30,
+        ];
+    }
+
+    /**
+     * Process a RAG query with mock data.
+     *
+     * @param string $userquery The user's query
+     * @return array The processed response
+     */
+    public function process_rag_query(string $userquery) {
+        return [
+            'answer' => [
+                [
+                    'id' => 1,
+                    'title' => 'Mock Course',
+                    'content' => 'Mock content for testing',
+                    'viewurl' => new \moodle_url('/course/view.php', ['id' => 1]),
+                ],
+            ],
+            'promptTokenCount' => 10,
+            'responseTokenCount' => 20,
+            'totalTokenCount' => 30,
+        ];
+    }
+
+    /**
+     * Initialize mock data.
+     */
+    public function data_initialization() {
+        global $DB;
+
+        // Create a test course with mock data.
+        $course = (object)[
+            'fullname' => 'Test Course',
+            'shortname' => 'TEST101',
+            'summary' => 'This is a test course for unit testing',
+            'visible' => 1,
+        ];
+
+        $courseid = $DB->insert_record('course', $course);
+
+        // Create mock embeddings for the course.
+        $content = $course->summary;
+        $embedding = array_fill(0, 384, 0.1);
+
+        $record = (object)[
+            'contenthash' => sha1($content),
+            'content' => $content,
+            'embedding' => serialize($embedding),
+            'moduleid' => $courseid,
+            'moduletype' => 'course',
+            'title' => $course->fullname,
+            'timecreated' => time(),
+            'timemodified' => time(),
+        ];
+
+        $DB->insert_record('block_terusrag', $record);
+    }
+
+    /**
+     * Get mock top ranked chunks.
+     *
+     * @param string $query The search query
+     * @return array The top-ranked content chunks
+     */
+    public function get_top_ranked_chunks(string $query): array {
+        return [
+            [
+                'content' => 'Mock chunk content for testing',
+                'id' => 1,
+            ],
+        ];
+    }
+}

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="../../../lib/phpunit/phpunit.xsd"
+    bootstrap="../../../lib/phpunit/bootstrap.php"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
+    processIsolation="false"
+    backupGlobals="false"
+    backupStaticAttributes="false"
+    cacheResult="false"
+    stopOnError="false"
+    stopOnFailure="false"
+    stopOnIncomplete="false"
+    stopOnSkipped="false"
+    beStrictAboutTestsThatDoNotTestAnything="false"
+    beStrictAboutOutputDuringTests="true"
+    >
+
+    <testsuites>
+        <testsuite name="block_terusrag_testsuite">
+            <directory suffix="_test.php">.</directory>
+        </testsuite>
+    </testsuites>
+
+    <coverage>
+        <include>
+            <directory suffix=".php">../classes</directory>
+        </include>
+    </coverage>
+</phpunit>

--- a/tests/provider_test.php
+++ b/tests/provider_test.php
@@ -1,0 +1,168 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace block_terusrag;
+
+defined('MOODLE_INTERNAL') || die;
+
+global $CFG;
+require_once($CFG->dirroot . '/blocks/terusrag/tests/mock_provider.php');
+
+/**
+ * Provider test case.
+ *
+ * @package    block_terusrag
+ * @copyright  2025 Terus e-Learning
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @coversDefaultClass \block_terusrag\provider
+ */
+class provider_test extends \advanced_testcase {
+
+    /** @var mock_provider */
+    private $provider;
+
+    /**
+     * Set up before each test.
+     */
+    protected function setUp(): void {
+        parent::setUp();
+        $this->resetAfterTest();
+        $this->provider = new mock_provider();
+    }
+
+    /**
+     * Test embedding generation.
+     *
+     * @covers ::get_embedding
+     */
+    public function test_get_embedding() {
+        // Test single input.
+        $query = "Test query";
+        $mockembedding = array_fill(0, 384, 0.5);
+        $this->provider->set_mock_embedding($query, $mockembedding);
+        $result = $this->provider->get_embedding($query);
+        $this->assertEquals($mockembedding, $result);
+
+        // Test batch input.
+        $queries = ["Query 1", "Query 2"];
+        $mockembeddings = [
+            array_fill(0, 384, 0.3),
+            array_fill(0, 384, 0.7),
+        ];
+        $this->provider->set_mock_embedding($queries, $mockembeddings);
+        $result = $this->provider->get_embedding($queries);
+        $this->assertEquals($mockembeddings, $result);
+
+        // Test default embedding.
+        $result = $this->provider->get_embedding("Unknown query");
+        $this->assertEquals(array_fill(0, 384, 0.0), $result);
+    }
+
+    /**
+     * Test LLM response generation.
+     *
+     * @covers ::get_response
+     */
+    public function test_get_response() {
+        // Test with mock response.
+        $prompt = "Test prompt";
+        $mockresponse = [
+            'content' => 'Custom mock response',
+            'promptTokenCount' => 15,
+            'responseTokenCount' => 25,
+            'totalTokenCount' => 40,
+        ];
+        $this->provider->set_mock_response($prompt, $mockresponse);
+        $result = $this->provider->get_response($prompt);
+        $this->assertEquals($mockresponse, $result);
+
+        // Test default response.
+        $result = $this->provider->get_response("Unknown prompt");
+        $this->assertArrayHasKey('content', $result);
+        $this->assertArrayHasKey('promptTokenCount', $result);
+        $this->assertArrayHasKey('responseTokenCount', $result);
+        $this->assertArrayHasKey('totalTokenCount', $result);
+    }
+
+    /**
+     * Test RAG query processing.
+     *
+     * @covers ::process_rag_query
+     */
+    public function test_process_rag_query() {
+        $result = $this->provider->process_rag_query("What courses are available?");
+
+        $this->assertArrayHasKey('answer', $result);
+        $this->assertArrayHasKey('promptTokenCount', $result);
+        $this->assertArrayHasKey('responseTokenCount', $result);
+        $this->assertArrayHasKey('totalTokenCount', $result);
+
+        $answer = $result['answer'][0];
+        $this->assertArrayHasKey('id', $answer);
+        $this->assertArrayHasKey('title', $answer);
+        $this->assertArrayHasKey('content', $answer);
+        $this->assertArrayHasKey('viewurl', $answer);
+    }
+
+    /**
+     * Test data initialization.
+     *
+     * @covers ::data_initialization
+     */
+    public function test_data_initialization() {
+        global $DB;
+
+        // Run initialization.
+        $this->provider->data_initialization();
+
+        // Verify course was created.
+        $courses = $DB->get_records('course');
+        $this->assertCount(2, $courses); // Default site course + our test course.
+
+        // Find our test course.
+        $testcourse = $DB->get_record('course', ['shortname' => 'TEST101']);
+        $this->assertNotFalse($testcourse);
+
+        // Verify embedding record was created.
+        $embedding = $DB->get_record('block_terusrag', ['moduleid' => $testcourse->id]);
+        $this->assertNotFalse($embedding);
+        $this->assertEquals('course', $embedding->moduletype);
+        $this->assertEquals($testcourse->fullname, $embedding->title);
+
+        // Verify embedding data.
+        $embeddingdata = unserialize($embedding->embedding);
+        $this->assertIsArray($embeddingdata);
+        $this->assertCount(384, $embeddingdata);
+    }
+
+    /**
+     * Test getting top ranked chunks.
+     *
+     * @covers ::get_top_ranked_chunks
+     */
+    public function test_get_top_ranked_chunks() {
+        $result = $this->provider->get_top_ranked_chunks("test query");
+
+        $this->assertIsArray($result);
+        $this->assertCount(1, $result);
+
+        $chunk = $result[0];
+        $this->assertArrayHasKey('content', $chunk);
+        $this->assertArrayHasKey('id', $chunk);
+        $this->assertEquals('Mock chunk content for testing', $chunk['content']);
+        $this->assertEquals(1, $chunk['id']);
+    }
+}

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2025040511;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2025040512;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2022111800;        // Requires this Moodle version (Moodle 4.1.3+).
 $plugin->component = 'block_terusrag'; // Full name of the plugin (used for diagnostics).
 $plugin->maturity = MATURITY_STABLE;
-$plugin->release = 'v1.0.5';
+$plugin->release = 'v1.0.6';

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2025032822;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2025040511;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2022111800;        // Requires this Moodle version (Moodle 4.1.3+).
 $plugin->component = 'block_terusrag'; // Full name of the plugin (used for diagnostics).
 $plugin->maturity = MATURITY_STABLE;
-$plugin->release = 'v1.0.4';
+$plugin->release = 'v1.0.5';


### PR DESCRIPTION
This pull request includes multiple changes to enhance the functionality of the Moodle block plugin, improve the codebase, and add testing capabilities. The most important changes include updating the plugin to support a new AI provider, adding a mock provider for testing, and modifying the database schema.

### Enhancements to Plugin Functionality:
* Added Ollama as a new AI provider, including support for multiple open-source models and local deployment options (`README.md`). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R9-R16) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L75-R88) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R97-R104) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L101-R132) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L123-R146)

### Codebase Improvements:
* Updated the `cosine_similarity` method in `classes/llm.php` to include a check for the existence of keys in the second vector (`classes/llm.php`).
* Enhanced the `get_top_ranked_chunks` method to verify that chunk embeddings are arrays before processing (`classes/openai.php`).

### Database Schema Modifications:
* Changed the unique key in the `block_terusrag` table to a composite key of `contenthash` and `moduleid` (`db/install.xml`, `db/upgrade.php`). [[1]](diffhunk://#diff-4013433adb48858dfeac13caf181742020b6c693bc853298312c45b134377cb6L21-R21) [[2]](diffhunk://#diff-fcb317575e9e6245fdf1590e51a86685b61c2cc9573a9df8034323ccb3ef614fR89-R104)

### Testing Additions:
* Introduced a mock provider class for testing purposes (`tests/mock_provider.php`).
* Added PHPUnit configuration and a test case for the mock provider (`tests/phpunit.xml`, `tests/provider_test.php`). [[1]](diffhunk://#diff-93cef3cc954f6c7ac67ddffaf2f31205e5ead5320577222aad8810842ff27c5cR1-R32) [[2]](diffhunk://#diff-abac3f80afdb632c3ff9312d8b3f8d21a233795dd5394bd86e7c436f88045b77R1-R168)

### Version Update:
* Updated the plugin version and release information in `version.php` to reflect the new changes (`version.php`).